### PR TITLE
Improve package manager detection in backup

### DIFF
--- a/BRCS.sh
+++ b/BRCS.sh
@@ -35,14 +35,17 @@ progress_bar() {
 
 # 💾 Function: Backup
 backup_configs() {
-    March=$(echo "$MACHTYPE" | cut -c8-13)
     echo "[+] Starting backup..."
     com1="locate"
     com2="zip"
     para="-r -9 -@"
 
     patterns=(.conf .ini .rules .sh /etc/fstab /etc/default/grub /etc/hostname)
-    [ "$March" != "redhat" ] && patterns+=(/etc/apt/sources.list*) || patterns+=(/etc/yum.repos.d/*)
+    if command -v apt >/dev/null; then
+        patterns+=(/etc/apt/sources.list*)
+    else
+        patterns+=(/etc/yum.repos.d/*)
+    fi
     total=${#patterns[@]}
     count=0
 


### PR DESCRIPTION
## Summary
- use `command -v` to identify the package manager in `backup_configs`
- drop unused `March` variable

## Testing
- `bash -n BRCS.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853611cf48483298cbbee1225b5ecd2