### PR TITLE
Add Bats test for progress_bar

### DIFF
--- a/BRCS.sh
+++ b/BRCS.sh
@@ -191,6 +191,9 @@ schedule_cleanup() {
 
 # 📋 Interactive Terminal Menu
 
+# Skip menu when sourced by tests or other scripts
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && return
+
 # Handle --limpeza for cron execution
 if [ "$1" == "--limpeza" ]; then
     limpeza_completa

--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ Logs are saved to `~/backup_YYYYMMDD.log`
 ## 📜 License
 
 This project is licensed under the terms of the [GNU General Public License v3.0](LICENSE).
+
+## Contributing
+
+To run the test suite you need the [Bats](https://github.com/bats-core/bats-core) framework.
+Install it via your package manager (e.g. `sudo apt install bats`) and then execute:
+
+```bash
+bats test
+```
+

--- a/test/progress_bar.bats
+++ b/test/progress_bar.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "progress_bar shows correct percentage" {
+  run bash -c 'source ./BRCS.sh >/dev/null; progress_bar 10 5'
+  [[ "$output" == *"50%"* ]]
+}


### PR DESCRIPTION
## Summary
- allow sourcing BRCS.sh without running the menu
- add Bats test for progress_bar
- document how to run tests in a new Contributing section

## Testing
- `bats test`


------
https://chatgpt.com/codex/tasks/task_e_6853612b1c488329829442682a9d2e9c