### PR TITLE
Update read invocations with -r flag

### DIFF
--- a/BRCS.sh
+++ b/BRCS.sh
@@ -68,7 +68,7 @@ backup_configs() {
 
 # 🔁 Function: Restore (interactive)
 restaurar_configs() {
-    read -p "📦 Enter the path to the backup file (.zip): " arquivo
+    read -r -p "📦 Enter the path to the backup file (.zip): " arquivo
     [ ! -f "$arquivo" ] && echo "❌ File not found." && return
 
     TMPDIR=$(mktemp -d)
@@ -82,7 +82,7 @@ restaurar_configs() {
     for FILE in "${files[@]}"; do
         DEST="/${FILE#$TMPDIR/}"
         echo "Restore $DEST? [y/N]"
-        read CONF
+        read -r CONF
         if [[ "$CONF" =~ ^[Yy]$ ]]; then
             sudo mkdir -p "$(dirname "$DEST")"
             sudo cp "$FILE" "$DEST"
@@ -99,7 +99,7 @@ restaurar_configs() {
 
 # 🔁 Function: Restore all (no prompt)
 restaurar_tudo() {
-    read -p "📦 Enter the path to the backup file (.zip): " arquivo
+    read -r -p "📦 Enter the path to the backup file (.zip): " arquivo
     [ ! -f "$arquivo" ] && echo "❌ File not found." && return
 
     TMPDIR=$(mktemp -d)
@@ -152,7 +152,7 @@ limpeza_completa() {
     count=$((count+1)); progress_bar "$total" "$count"
 
     sudo snap set system refresh.retain=2
-    sudo snap list --all | awk '/disabled/{print $1, $2}' | while read snapname revision; do
+    sudo snap list --all | awk '/disabled/{print $1, $2}' | while read -r snapname revision; do
         sudo snap remove "$snapname" --revision="$revision" --purge 2>/dev/null || \
         sudo snap remove "$snapname" --purge
     done
@@ -211,7 +211,7 @@ while true; do
     echo "3️⃣  Full system cleanup"
     echo "4️⃣  Schedule cleanup at boot"
     echo "5️⃣  Exit"
-    read -p "Choose an option: " option
+    read -r -p "Choose an option: " option
 
     case "$option" in
         1) backup_configs ;;
@@ -221,7 +221,7 @@ while true; do
             echo "1 - Interactive restore"
             echo "2 - Restore all (no prompt)"
             echo "3 - Back"
-            read -p "Choose an option: " restopt
+            read -r -p "Choose an option: " restopt
             case "$restopt" in
                 1) restaurar_configs ;;
                 2) restaurar_tudo ;;


### PR DESCRIPTION
## Summary
- ensure `read` invocations use `-r` in `BRCS.sh`
- keep interactive prompts the same but now using `read -r`

## Testing
- `bats test`

------
https://chatgpt.com/codex/tasks/task_e_6859da0c44d48329acc868aceac674a9