### PR TITLE
Fix DEST quoting for ShellCheck

### DIFF
--- a/BRCS.sh
+++ b/BRCS.sh
@@ -80,7 +80,7 @@ restaurar_configs() {
 
     echo "🔁 Restoring files..."
     for FILE in "${files[@]}"; do
-        DEST="/${FILE#$TMPDIR/}"
+        DEST="/${FILE#"$TMPDIR"/}"
         echo "Restore $DEST? [y/N]"
         read CONF
         if [[ "$CONF" =~ ^[Yy]$ ]]; then
@@ -111,7 +111,7 @@ restaurar_tudo() {
 
     echo "🔁 Restoring all files..."
     for FILE in "${files[@]}"; do
-        DEST="/${FILE#$TMPDIR/}"
+        DEST="/${FILE#"$TMPDIR"/}"
         sudo mkdir -p "$(dirname "$DEST")"
         sudo cp "$FILE" "$DEST"
         echo "[✅] Restored: $DEST"


### PR DESCRIPTION
## Summary
- escape `$TMPDIR` in parameter expansion when restoring files
- fix SC2295 ShellCheck warning

## Testing
- `shellcheck BRCS.sh`
- `bats test`

------
https://chatgpt.com/codex/tasks/task_e_6859da0e82b883299526475afb34f755